### PR TITLE
Fixed URL Configuration in define('MOE_URL') to Resolve Routing Issue

### DIFF
--- a/static/php/settings.inc.php
+++ b/static/php/settings.inc.php
@@ -25,4 +25,4 @@ define('FILES_ROOT', '/var/www/files/');
 define('PU_NAME', 'Uguu');
 define('PU_ADDRESS', 'uguu.se');
 define('PU_SERVE_URL', 'https://a.uguu.se/');
-define('MOE_URL', 'https://moepanel.uguu.se');
+define('MOE_URL', 'https://moepanel.uguu.se/');


### PR DESCRIPTION
Issue: Without the trailing slash, users were directed to https://moepanel.uguu.sedashboard/index.php instead of the correct https://moepanel.uguu.se/dashboard/index.php. The addition of the slash ensures the proper routing to the intended URL.

Fix: Added a missing slash in the define('MOE_URL') configuration to ensure users are directed to the correct URL.